### PR TITLE
Fix/lost messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "@vscode/vsce": "^2.19.0",
     "eslint": "^8.41.0",
     "eslint-plugin-filenames": "^1.3.2",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.1.3"
+    "ts-node": "^10.9.1"
   },
   "engines": {
     "node": ">=18",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/vscode-async-webview-backend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "repository": "github:stack-spot/vscode-async-webview",
   "main": "out/index.js",
   "module": "out/index.mjs",
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stack-spot/vscode-async-webview-shared": "^0.4.0",
+    "@stack-spot/vscode-async-webview-shared": "^0.6.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
@@ -24,6 +24,6 @@
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-esbuild": "^5.0.0",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.9.4"
+    "typescript": "4.9.4"
   }
 }

--- a/packages/backend/src/VSCodeWebviewBridge.ts
+++ b/packages/backend/src/VSCodeWebviewBridge.ts
@@ -42,7 +42,7 @@ export abstract class VSCodeWebviewBridge<StateType extends object = Record<stri
         const member = this[name as keyof this]
         return typeof member === 'function' ? (...args: any[]) => (member as AnyFunction).apply(this, args) : undefined
       },
-      sendMessageToClient: (message) => webview.postMessage.apply(webview, [message]),
+      sendMessageToClient: async (message) => webview.postMessage.apply(webview, [message]),
       listenToMessagesFromClient: (listener) => {
         webview.onDidReceiveMessage((data) => {
           logger.debug('received message from client:', data)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/vscode-async-webview-client",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "repository": "github:stack-spot/vscode-async-webview",
   "main": "out/index.js",
   "module": "out/index.mjs",
@@ -9,10 +9,10 @@
     "compile": "rollup -c"
   },
   "dependencies": {
-    "@stack-spot/vscode-async-webview-shared": "^0.4.0"
+    "@stack-spot/vscode-async-webview-shared": "^0.6.0"
   },
   "devDependencies": {
-    "typescript": "^4.9.4",
+    "typescript": "4.9.4",
     "esbuild": "^0.18.16",
     "rollup": "^3.26.3",
     "rollup-plugin-dts": "^5.3.0",

--- a/packages/client/src/VSCodeWeb.ts
+++ b/packages/client/src/VSCodeWeb.ts
@@ -12,6 +12,7 @@ import {
   StateTypeOf,
   logger,
   buildGetStateError,
+  readyMessage,
 } from '@stack-spot/vscode-async-webview-shared'
 import { LinkedBridge, VSCodeWebInterface } from './VSCodeWebInterface'
 
@@ -46,6 +47,7 @@ export class VSCodeWeb<Bridge extends AsyncStateful<any> = AsyncStateful<Record<
     if (!stored) VSCodeWeb.vscode.setState(initialState)
     this.state = VSCodeWeb.vscode.getState()
     this.addWindowListener()
+    VSCodeWeb.sendMessageToExtension(readyMessage)
   }
 
   /**

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/vscode-async-webview-react",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "repository": "github:stack-spot/vscode-async-webview",
   "main": "out/index.js",
   "module": "out/index.mjs",
@@ -12,7 +12,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "@stack-spot/vscode-async-webview-client": ">=0.4.0"
+    "@stack-spot/vscode-async-webview-client": ">=0.6.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
     "@types/node": "20.2.5",
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
-    "typescript": "^4.9.4",
+    "typescript": "4.9.4",
     "web-vitals": "^2.1.4",
     "esbuild": "^0.18.16",
     "rollup": "^3.26.3",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
-import { StateTypeOf, VSCodeWebInterface } from '@stack-spot/vscode-async-webview-client'
+import { AsyncStateful, StateTypeOf, VSCodeWebInterface } from '@stack-spot/vscode-async-webview-client'
 
 interface VSCodeHooks<T extends VSCodeWebInterface> {
   useState: <
@@ -10,7 +10,7 @@ interface VSCodeHooks<T extends VSCodeWebInterface> {
   >(key: Key) => [State[Key], Dispatch<SetStateAction<State[Key]>>],
 }
 
-export function createVSCodeHooks<T extends VSCodeWebInterface>(vscode: T): VSCodeHooks<T> {
+export function createVSCodeHooks<T extends VSCodeWebInterface<AsyncStateful<any>>>(vscode: T): VSCodeHooks<T> {
   return {
     useState: (key) => {
       const [value, setValue] = useState(vscode.getState(key))

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stack-spot/vscode-async-webview-shared",
   "repository": "github:stack-spot/vscode-async-webview",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "main": "out/index.js",
   "module": "out/index.mjs",
   "typings": "out/index.d.ts",
@@ -13,7 +13,7 @@
     "rollup": "^3.26.3",
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-esbuild": "^5.0.0",
-    "typescript": "^4.9.4"
+    "typescript": "4.9.4"
   },
   "dependencies": {
     "uid": "^2.0.2"

--- a/packages/shared/src/message.ts
+++ b/packages/shared/src/message.ts
@@ -4,6 +4,7 @@ export const messageType = {
   bridge: 'vscode-webview:bridge',
   getState: 'vscode-webview:get-state',
   setState: 'vscode-webview:set-state',
+  ready: 'vscode-webview-ready',
 } as const
 
 export type MessageType = (typeof messageType)[keyof typeof messageType]
@@ -78,3 +79,6 @@ export function buildSetStateResponse(id: string): WebviewResponseMessage {
 export function buildSetStateError(id: string, error: string): WebviewResponseMessage {
   return { type: messageType.setState, id, error }
 }
+
+/* Ready message */
+export const readyMessage: WebviewMessage = { type: 'vscode-webview-ready', id: 'vscode-webview-ready' }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
   packages/react:
     dependencies:
       '@stack-spot/vscode-async-webview-client':
-        specifier: '>=0.4.0'
+        specifier: '>=0.6.0'
         version: link:../client
       react:
         specifier: ^18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
         version: 20.2.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.8
-        version: 5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.41.0)(typescript@5.1.3)
+        version: 5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.41.0)(typescript@4.9.4)
       '@typescript-eslint/parser':
         specifier: ^5.59.8
-        version: 5.59.8(eslint@8.41.0)(typescript@5.1.3)
+        version: 5.59.8(eslint@8.41.0)(typescript@4.9.4)
       '@vscode/vsce':
         specifier: ^2.19.0
         version: 2.19.0
@@ -27,15 +27,12 @@ importers:
         version: 1.3.2(eslint@8.41.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@20.2.5)(typescript@5.1.3)
-      typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        version: 10.9.1(@types/node@20.2.5)(typescript@4.9.4)
 
   packages/backend:
     dependencies:
       '@stack-spot/vscode-async-webview-shared':
-        specifier: ^0.4.0
+        specifier: ^0.6.0
         version: link:../shared
       lodash:
         specifier: ^4.17.21
@@ -72,13 +69,13 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@babel/core@7.22.10)(esbuild@0.18.16)(jest@29.6.2)(typescript@4.9.4)
       typescript:
-        specifier: ^4.9.4
+        specifier: 4.9.4
         version: 4.9.4
 
   packages/client:
     dependencies:
       '@stack-spot/vscode-async-webview-shared':
-        specifier: ^0.4.0
+        specifier: ^0.6.0
         version: link:../shared
     devDependencies:
       esbuild:
@@ -94,7 +91,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(esbuild@0.18.16)(rollup@3.26.3)
       typescript:
-        specifier: ^4.9.4
+        specifier: 4.9.4
         version: 4.9.4
 
   packages/react:
@@ -146,7 +143,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(esbuild@0.18.16)(rollup@3.26.3)
       typescript:
-        specifier: ^4.9.4
+        specifier: 4.9.4
         version: 4.9.4
       web-vitals:
         specifier: ^2.1.4
@@ -171,7 +168,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(esbuild@0.18.16)(rollup@3.26.3)
       typescript:
-        specifier: ^4.9.4
+        specifier: 4.9.4
         version: 4.9.4
 
 packages:
@@ -3393,35 +3390,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/eslint-plugin@5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-JDMOmhXteJ4WVKOiHXGCoB96ADWg9q7efPWHRViT/f09bA8XOMLAVHHju3l0MkZnG1izaWXYmgvQcUjTRcpShQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/scope-manager': 5.59.8
-      '@typescript-eslint/type-utils': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
-      debug: 4.3.4
-      eslint: 8.41.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/experimental-utils@5.62.0(eslint@8.41.0)(typescript@4.9.4):
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
@@ -3454,27 +3422,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/parser@5.59.8(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-AnR19RjJcpjoeGojmwZtCwBX/RidqDZtzcbG3xHrmz0aHHoOcbWnpDllenRDmDvsV0RQ6+tbb09/kyc+UT9Orw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.59.8
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/typescript-estree': 5.59.8(typescript@5.1.3)
-      debug: 4.3.4
-      eslint: 8.41.0
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/scope-manager@5.59.8:
     resolution: {integrity: sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==}
@@ -3509,27 +3456,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/type-utils@5.59.8(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-+5M518uEIHFBy3FnyqZUF3BMP+AXnYn4oyH8RF012+e7/msMY98FhGL5SrN29NQ9xDgvqCgYnsOiKp1VjZ/fpA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.8(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
-      debug: 4.3.4
-      eslint: 8.41.0
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/types@5.59.8:
     resolution: {integrity: sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==}
@@ -3559,28 +3485,6 @@ packages:
       typescript: 4.9.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@typescript-eslint/typescript-estree@5.59.8(typescript@5.1.3):
-    resolution: {integrity: sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/visitor-keys': 5.59.8
-      debug: 4.3.4
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.4):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -3621,27 +3525,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
-
-  /@typescript-eslint/utils@5.59.8(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-Tr65630KysnNn9f9G7ROF3w1b5/7f6QVCJ+WK9nhIocWmx9F+TmCAcglF26Vm7z8KCTwoKcNEBZrhlklla3CKg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.59.8
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/typescript-estree': 5.59.8(typescript@5.1.3)
-      eslint: 8.41.0
-      eslint-scope: 5.1.1
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.41.0)(typescript@4.9.4):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -7474,7 +7357,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@20.2.5)(typescript@5.1.3)
+      ts-node: 10.9.1(@types/node@20.2.5)(typescript@4.9.4)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -7517,7 +7400,7 @@ packages:
       pretty-format: 29.6.2
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@20.2.5)(typescript@5.1.3)
+      ts-node: 10.9.1(@types/node@20.2.5)(typescript@4.9.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -9568,7 +9451,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.27
-      ts-node: 10.9.1(@types/node@20.2.5)(typescript@5.1.3)
+      ts-node: 10.9.1(@types/node@20.2.5)(typescript@4.9.4)
       yaml: 2.3.1
     dev: false
 
@@ -11684,7 +11567,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@20.2.5)(typescript@5.1.3):
+  /ts-node@10.9.1(@types/node@20.2.5)(typescript@4.9.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -11710,7 +11593,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.1.3
+      typescript: 4.9.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -11738,17 +11621,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.4
-    dev: false
-
-  /tsutils@3.21.0(typescript@5.1.3):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.3
-    dev: true
 
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}
@@ -11873,11 +11745,6 @@ packages:
   /typescript@4.9.4:
     resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
-    hasBin: true
-
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
-    engines: {node: '>=14.17'}
     hasBin: true
 
   /uc.micro@1.0.6:


### PR DESCRIPTION
When VSCode kills the webview (another panel is selected), all messages sent from the main process (extension) are lost.

This PR creates a queue of messages that is filled whenever the webview is not available. When the webview becomes available again, all messages in the queue are sent.