### PR TITLE
safer streaming

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/vscode-async-webview-backend",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "repository": "github:stack-spot/vscode-async-webview",
   "main": "out/index.js",
   "module": "out/index.mjs",

--- a/packages/backend/src/VSCodeWebviewBridge.ts
+++ b/packages/backend/src/VSCodeWebviewBridge.ts
@@ -58,7 +58,7 @@ export abstract class VSCodeWebviewBridge<StateType extends Record<string, any> 
    * @param message the package to send.
    */
   stream(message: Omit<WebviewStreamMessage, 'type' | 'index'>) {
-    this.#messageHandler.stream({ ...message, type: 'vscode-webview-stream' })
+    this.#messageHandler.stream(message)
   }
 
   dispose() {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stack-spot/vscode-async-webview-react",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "repository": "github:stack-spot/vscode-async-webview",
   "main": "out/index.js",
   "module": "out/index.mjs",


### PR DESCRIPTION
Fixes problems related to streaming content from the extension to the Webview.

1. The React hook now receives the full streamed string in the events `onError`, `onSuccess` and `onFinish`. Allowing the developer to properly store the result in a persistent state.
2. If the Webview closes before the streaming finishes, the content is no longes lost. When the Webview is recreated, the streaming is resumed.